### PR TITLE
正規表現の変数を削除し、記述量を削減

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,6 @@
 class Message < ApplicationRecord
   validates :message, presence: true, length: { minimum: 1, maximum: 50 }
-  HIRAGANA_REGEXP = /\A[ぁ-んー－]+\z/
-  validates :message, format: { with: HIRAGANA_REGEXP }
+  validates :message, format: { with: /\A[ぁ-んー－]+\z/ }
   validates :reverse_message, presence: true, length: { minimum: 1, maximum: 100 }
   
   def to_param


### PR DESCRIPTION
## 概要

・ひらがなのバリデーションをかける際に`HIRAGANA_REGEXP = /\A[ぁ-んー－]+\z/`と記述していたコードを削除し、記述量を削減。
・HIRAGANA_REGEXP変数は1箇所でした使用していなかったので、  `validates :message, format: { with: /\A[ぁ-んー－]+\z/ }`の形で直接記述。