### PR TITLE
Update: bundle update --conservative reverse_playback_wordを実行し、特定のgemを更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1467,7 +1467,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    reverse_playback_word (0.1.0)
+    reverse_playback_word (0.1.1)
     rexml (3.2.5)
     romkan (0.4.0)
     rspec-core (3.11.0)


### PR DESCRIPTION
## 概要

`gem 'reverse_playback_word'`のVERSIONを0.1.0 -> 0.1.1に更新（変換後「を」ではなく「お」を優先的に表示させる記述に変更）したため、そのgemのみ` bundle update --conservative reverse_playback_word`を実行し、更新