### PR TITLE
【セキュリティ対策】脆弱性検知のためgem 'brakeman'を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'brakeman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1296,6 +1296,7 @@ GEM
       debug_inspector (>= 0.0.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
+    brakeman (5.2.3)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)
@@ -1600,6 +1601,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.4)
+  brakeman
   byebug
   capybara
   cloudinary


### PR DESCRIPTION
## 概要

■実行コマンド
`bundle exec brakeman
`
■結果
警告0のため、現状は問題なし。

■参考記事
＜Brakeman Github＞
https://github.com/presidentbeef/brakeman
＜gem BrakemanでRails製アプリケーションの脆弱性を検知する＞
https://techblog.gmo-ap.jp/2021/12/06/rails-brakeman
